### PR TITLE
return error if len(user) retrieved from rpc metadata == 0

### DIFF
--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -109,12 +109,12 @@ func AuthorizeUser(ctx context.Context) (string, bool) {
 		return "no Metadata found", authorize
 	}
 	user, ok := headers[usernameKey]
-	if !ok && len(user) > 0 {
+	if !ok || len(user) == 0 {
 		return "no username in Metadata", authorize
 	}
 	pass, ok := headers[passwordKey]
-	if !ok && len(pass) > 0 {
-		return "found username \"%s\" but no password in Metadata", authorize
+	if !ok || len(pass) == 0 {
+		return fmt.Sprintf("found username \"%s\" but no password in Metadata", user[0]), authorize
 	}
 	if authorize || pass[0] == authorizedUser.password && user[0] == authorizedUser.username {
 		return fmt.Sprintf("authorized with \"%s:%s\"", user[0], pass[0]), true


### PR DESCRIPTION
I encountered a crash when sending a RPC message without username (and/or password) from the client. 
```
github.com/samribeiro/gnmi/credentials.AuthorizeUser(0x1c51000, 0xc420018330, 0x0, 0x0, 0x40)
	/Users/davide/Development/Go/src/github.com/samribeiro/gnmi/credentials/credentials.go:121 +0x34b
main.(*server).Get(0x16d35b8, 0x1c51000, 0xc420018330, 0xc42007f740, 0x16d35b8, 0x102929e, 0x0)
	/Users/davide/Development/Go/src/github.com/samribeiro/gnmi/gnmi_target/gnmi_target.go:43 +0x4d
github.com/openconfig/gnmi/proto/gnmi._GNMI_Get_Handler(0x14171c0, 0x16d35b8, 0x1c51000, 0xc420018330, 0xc42025e460, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/packages/src/github.com/openconfig/gnmi/proto/gnmi/gnmi.pb.go:1935 +0x28d
google.golang.org/grpc.(*Server).processUnaryRPC(0xc420117400, 0x167d7a0, 0xc42015a480, 0xc42000a500, 0xc4201565d0, 0x16ae638, 0xc4201579b0, 0x0, 0x0)
	/usr/local/go/packages/src/google.golang.org/grpc/server.go:806 +0xc41
google.golang.org/grpc.(*Server).handleStream(0xc420117400, 0x167d7a0, 0xc42015a480, 0xc42000a500, 0xc4201579b0)
	/usr/local/go/packages/src/google.golang.org/grpc/server.go:1006 +0x15a6
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc42025a1b0, 0xc420117400, 0x167d7a0, 0xc42015a480, 0xc42000a500)
	/usr/local/go/packages/src/google.golang.org/grpc/server.go:552 +0xa9
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/usr/local/go/packages/src/google.golang.org/grpc/server.go:553 +0xa1
```

I changed the check for the presence of username and password in metadata from `if !ok && len(user) > 0` to `if !ok || len(user) == 0`.

```
$ ./gnmi_target  -bind_address :50052 -key ../cert2/server.key -cert ../cert2/server.crt -ca ../cert2/ca.crt -alsologtostderr
I0828 10:39:26.478371   68004 gnmi_target.go:70] starting to listen on :50052
I0828 10:39:26.478985   68004 gnmi_target.go:76] starting to serve
I0828 10:41:27.833893   68004 gnmi_target.go:48] served a Get request,  no username in Metadata
I0828 10:42:17.539654   68004 gnmi_target.go:48] served a Get request,  found username "davide" but no password in Metadata
I0828 10:42:27.018564   68004 gnmi_target.go:48] served a Get request,  authorized with "davide:mysecretpassword"
```